### PR TITLE
Develop

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@ FROM golang:alpine AS build
 RUN apk update && apk add git curl
 
 # Declare base dir
-WORKDIR /go/src/github.com/10gen/stitch-cli
+WORKDIR $GOPATH/src/github.com/10gen/stitch-cli
 
 RUN git clone https://github.com/10gen/stitch-cli.git .
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -33,4 +33,4 @@ RUN apk update && apk add --no-cache ca-certificates
 
 COPY --from=build /go/src/github.com/10gen/stitch-cli/stitch-cli /usr/bin/
 
-CMD ["/bin/sh"]
+ENTRYPOINT ["/usr/bin/stitch-cli"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,9 +3,8 @@
 FROM golang:alpine AS build
 
 # Do a system update
-RUN apk update
-
-RUN apk add git curl
+# No need to put this into separate steps.
+RUN apk update && apk add git curl
 
 # Declare base dir
 WORKDIR /root/src

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,21 +7,18 @@ FROM golang:alpine AS build
 RUN apk update && apk add git curl
 
 # Declare base dir
-WORKDIR /root/src
+WORKDIR /go/src/github.com/10gen/stitch-cli
 
-RUN git clone https://github.com/10gen/stitch-cli.git
-
-WORKDIR /root/src/stitch-cli
+RUN git clone https://github.com/10gen/stitch-cli.git .
 
 # Remove the old dependencies
 RUN rm -rf vendor
 
 # Fetch the dependencies
 RUN curl https://raw.githubusercontent.com/golang/dep/master/install.sh | sh
-RUN GOPATH=$GOPATH:/root dep ensure
 
-# Now it should build
-RUN GOPATH=$GOPATH:/root go build
+# We build in case all depencies are pulled in corrctly.
+RUN dep ensure && go build
 
 # Second stage build to just expose the command
 FROM alpine:3.9
@@ -30,11 +27,10 @@ FROM alpine:3.9
 WORKDIR /project
 
 # Do a system update
-RUN apk update
+# We can run it in one step, as it is more likely that an update
+# is available than that ca-certificates have changed
+RUN apk update && apk add --no-cache ca-certificates
 
-# Add required stuff
-RUN apk add ca-certificates
-
-COPY --from=build /root/src/stitch-cli/stitch-cli /usr/bin/
+COPY --from=build /go/src/github.com/10gen/stitch-cli/stitch-cli /usr/bin/
 
 CMD ["/bin/sh"]

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ To build the image:
 
 To run the image:
 
-    docker run -it stitch-cli stitch-cli --help
+    docker run -it --rm stitch-cli --help
 
 You will need to add a volume statement to the `run` command for the import/export commands, so that your project can be read or written.
 
@@ -26,16 +26,16 @@ The command saves authentication data in `~/.config/stitch/stitch`, so you will 
 So, a workflow could look like this:
 
     # Log in
-    docker run -it --volume=/home/youruser/.config/stitch:/root/.config/stitch -it stitch-cli stitch-cli login --username=youremail@example.com --api-key=01234567-abcd-efgh-ijkl-mnopqrstuvwx
+    docker run --rm -it --volume=/home/youruser/.config/stitch:/root/.config/stitch stitch-cli login --username=youremail@example.com --api-key=01234567-abcd-efgh-ijkl-mnopqrstuvwx
 
     # Check you're logged in
-    docker run -it --volume=/home/youruser/.config/stitch:/root/.config/stitch -it stitch-cli whoami
+    docker run --rm -it --volume=/home/youruser/.config/stitch:/root/.config/stitch stitch-cli whoami
 
     # Import to Stitch, assumes you're in a local Stitch project folder
-    docker run -it --volume=/home/youruser/.config/stitch:/root/.config/stitch --volume=`pwd`:/project -it stitch-cli stitch-cli import --strategy=merge
+    docker run --rm -it --volume=/home/youruser/.config/stitch:/root/.config/stitch --volume=`pwd`:/project stitch-cli import --strategy=merge
 
     # Export from Stitch, this will copy it to /tmp/project/out on the host
-    docker run -it --volume=/home/youruser/.config/stitch:/root/.config/stitch --volume=/tmp/project:/project stitch-cli stitch-cli export --app-id=stackwatcher-prod-keysc --output=/project/out
+    docker run --rm -it --volume=/home/youruser/.config/stitch:/root/.config/stitch --volume=/tmp/project:/project stitch-cli stitch-cli export --app-id=stackwatcher-prod-keysc --output=/project/out
 
 Status
 ---


### PR DESCRIPTION
Added a few nuts and bolts:

1. The build stage does not benefit much from running stuff in separate commands, so I moved the update and the installation calls to apk into one step
2. As mentioned on SO, there is a predefined GOPATH in the Golang images, so it should be used as per principle of least surprise. It does not impair the robustness, as the actual environment variable is used.
3. I changed the actual call to the binary from a CMD into an ENTRYPOINT. That prevents stuttering (`stitch-cli stitch-cli`) and makes it more user friendly.